### PR TITLE
2020-12-11 GUARD-595 Tracking-Numbers

### DIFF
--- a/src/NetSuiteAccess/Models/SalesOrder.cs
+++ b/src/NetSuiteAccess/Models/SalesOrder.cs
@@ -13,6 +13,12 @@ namespace NetSuiteAccess.Models
 		public decimal TaxTotal { get; set; }
 		public string DiscountName { get; set; }
 		public NetSuiteDiscountTypeEnum DiscountType { get; set; }
+		public IEnumerable< NetSuiteSalesOrderFulfillment > Fulfillments { get; set; }
+
+		public NetSuiteSalesOrder()
+		{
+			this.Fulfillments = new List< NetSuiteSalesOrderFulfillment >();
+		}
 	}
 
 	public class NetSuiteSalesOrderItem

--- a/src/NetSuiteAccess/Models/SalesOrderFulfillment.cs
+++ b/src/NetSuiteAccess/Models/SalesOrderFulfillment.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NetSuiteAccess.Models
+{
+	public class NetSuiteSalesOrderFulfillment
+	{
+		/// <summary>
+		///	Internal id
+		/// </summary>
+		public string Id { get; set; }
+		/// <summary>
+		///	Ref. no.
+		/// </summary>
+		public string TransactionId { get; set; }
+		public DateTime CreatedDateUtc { get; set; }
+		public DateTime LastModifiedDateUtc { get; set; }
+		/// <summary>
+		///	Picked, packed or shipped
+		/// </summary>
+		public NetSuiteSalesOrderFulfillmentStatusEnum Status { get; set; }
+		public NetSuiteSalesOrderFulfillmentCarrierEnum ShipmentCarrier { get; set; }
+		public string ShipmentClass { get; set; }
+		public decimal ShippingCost { get; set; }
+		/// <summary>
+		///	Memo
+		/// </summary>
+		public string Note { get; set; }
+		public IEnumerable< NetSuiteSalesOrderFulfillmentItem > Items { get; set; }
+		public IEnumerable< NetSuiteSalesOrderFulfillmentPackage > Packages { get; set; }
+
+		public NetSuiteSalesOrderFulfillment()
+		{
+			this.Items = new List< NetSuiteSalesOrderFulfillmentItem >();
+			this.Packages = new List< NetSuiteSalesOrderFulfillmentPackage >();
+		}
+	}
+
+	public enum NetSuiteSalesOrderFulfillmentStatusEnum { Unknown, Picked, Packed, Shipped }
+	public enum NetSuiteSalesOrderFulfillmentCarrierEnum { Other, FedEx, USPS, UPS }
+
+	public class NetSuiteSalesOrderFulfillmentItem
+	{
+		public string Name { get; set; }
+		public int Quantity { get; set; }
+	}
+
+	public class NetSuiteSalesOrderFulfillmentPackage
+	{
+		public decimal WeightLbs { get; set; }
+		public string TrackingNumber { get; set; }
+		public string ContentsDescription { get; set; }
+		public decimal LengthInches { get; set; }
+		public decimal WidthInches { get; set; }
+		public decimal HeightInches { get; set; }
+		public decimal InsuranceCost { get; set; }
+	}
+
+	public static class SalesOrderFulfillmentExtensions
+	{
+		public static Dictionary< NetSuiteSoapWS.ItemFulfillmentShipStatus, NetSuiteSalesOrderFulfillmentStatusEnum > FulfillmentStatuses { get; private set; }
+
+		static SalesOrderFulfillmentExtensions()
+		{
+			FulfillmentStatuses = new Dictionary< NetSuiteSoapWS.ItemFulfillmentShipStatus, NetSuiteSalesOrderFulfillmentStatusEnum >
+			{
+				{ NetSuiteSoapWS.ItemFulfillmentShipStatus._picked, NetSuiteSalesOrderFulfillmentStatusEnum.Picked },
+				{ NetSuiteSoapWS.ItemFulfillmentShipStatus._packed, NetSuiteSalesOrderFulfillmentStatusEnum.Packed },
+				{ NetSuiteSoapWS.ItemFulfillmentShipStatus._shipped, NetSuiteSalesOrderFulfillmentStatusEnum.Shipped }
+			};
+		}
+
+		public static NetSuiteSalesOrderFulfillment ToSVSalesOrderFulfillment( this NetSuiteSoapWS.ItemFulfillment orderFulfillment )
+		{
+			var svOrderFulfillment = new NetSuiteSalesOrderFulfillment()
+			{
+				Id = orderFulfillment.internalId,
+				TransactionId = orderFulfillment.tranId,
+				CreatedDateUtc = orderFulfillment.createdDate.ToUniversalTime(),
+				LastModifiedDateUtc = orderFulfillment.lastModifiedDate.ToUniversalTime(),
+				Status = ToSVSalesOrderFulfillmentStatus( orderFulfillment.shipStatus ),
+				ShipmentCarrier = GetSVSalesOrderFulfillmentCarrier( orderFulfillment ),
+				ShipmentClass = orderFulfillment.shipMethod?.name,
+				ShippingCost = (decimal)orderFulfillment.shippingCost,
+				Note = orderFulfillment.memo,
+				Items = orderFulfillment.itemList.ToSVSalesOrderFulfillmentItems(),
+				Packages = GetSVSalesOrderFullfillmentPackages( orderFulfillment )
+			};
+
+			return svOrderFulfillment;
+		}
+
+		private static NetSuiteSalesOrderFulfillmentStatusEnum ToSVSalesOrderFulfillmentStatus( NetSuiteSoapWS.ItemFulfillmentShipStatus status )
+		{
+			if ( !FulfillmentStatuses.TryGetValue( status, out NetSuiteSalesOrderFulfillmentStatusEnum salesOrderFulfillmentStatus ) )
+			{
+				return NetSuiteSalesOrderFulfillmentStatusEnum.Unknown;
+			}
+
+			return salesOrderFulfillmentStatus;
+		}
+
+		private static IEnumerable< NetSuiteSalesOrderFulfillmentItem > ToSVSalesOrderFulfillmentItems( this NetSuiteSoapWS.ItemFulfillmentItemList itemList )
+		{
+			var svSalesOrderFulfillmentItems = new List< NetSuiteSalesOrderFulfillmentItem >();
+
+			if ( itemList?.item == null || itemList.item.Length == 0 )
+				return svSalesOrderFulfillmentItems;
+
+			foreach( var fulfillmentItem in itemList.item )
+			{
+				svSalesOrderFulfillmentItems.Add( new NetSuiteSalesOrderFulfillmentItem()
+				{
+					Name = fulfillmentItem.itemName,
+					Quantity = (int)fulfillmentItem.quantity
+				} );
+			}
+
+			return svSalesOrderFulfillmentItems;
+		}
+
+		private static IEnumerable< NetSuiteSalesOrderFulfillmentPackage > GetSVSalesOrderFullfillmentPackages( NetSuiteSoapWS.ItemFulfillment orderFulfillment )
+		{
+			if ( orderFulfillment.packageFedExList != null )
+				return orderFulfillment.packageFedExList.ToSVSalesOrderFulfillmentPackages();
+
+			if ( orderFulfillment.packageUspsList != null )
+				return orderFulfillment.packageUspsList.ToSVSalesOrderFulfillmentPackages();
+
+			if ( orderFulfillment.packageUpsList != null )
+				return orderFulfillment.packageUpsList.ToSVSalesOrderFulfillmentPackages();
+
+			return orderFulfillment.packageList.ToSVSalesOrderFulfillmentPackages();
+		}
+
+		public static NetSuiteSalesOrderFulfillmentCarrierEnum GetSVSalesOrderFulfillmentCarrier( NetSuiteSoapWS.ItemFulfillment orderFulfillment )
+		{
+			if ( orderFulfillment.packageFedExList != null )
+				return NetSuiteSalesOrderFulfillmentCarrierEnum.FedEx;
+
+			if ( orderFulfillment.packageUspsList != null )
+				return NetSuiteSalesOrderFulfillmentCarrierEnum.USPS;
+
+			if ( orderFulfillment.packageUpsList != null )
+				return NetSuiteSalesOrderFulfillmentCarrierEnum.UPS;
+
+			return NetSuiteSalesOrderFulfillmentCarrierEnum.Other;
+		}
+
+		private static IEnumerable< NetSuiteSalesOrderFulfillmentPackage > ToSVSalesOrderFulfillmentPackages( this NetSuiteSoapWS.ItemFulfillmentPackageList packagesList )
+		{
+			var svSalesOrderFulfillmentPackages = new List< NetSuiteSalesOrderFulfillmentPackage >();
+			if ( packagesList?.package == null || packagesList.package.Length == 0 )
+				return svSalesOrderFulfillmentPackages;
+
+			foreach( var package in packagesList.package )
+			{
+				svSalesOrderFulfillmentPackages.Add( new NetSuiteSalesOrderFulfillmentPackage()
+				{
+					TrackingNumber = package.packageTrackingNumber,
+					WeightLbs = (decimal)package.packageWeight,
+					ContentsDescription = package.packageDescr
+				} );
+			}
+
+			return svSalesOrderFulfillmentPackages;
+		}
+
+		private static IEnumerable< NetSuiteSalesOrderFulfillmentPackage > ToSVSalesOrderFulfillmentPackages( this NetSuiteSoapWS.ItemFulfillmentPackageFedExList fedExPackagesList )
+		{
+			var svSalesOrderFulfillmentPackages = new List< NetSuiteSalesOrderFulfillmentPackage >();
+			if ( fedExPackagesList?.packageFedEx == null || fedExPackagesList.packageFedEx.Length == 0 )
+				return svSalesOrderFulfillmentPackages;
+
+			foreach( var fedExPackage in fedExPackagesList.packageFedEx )
+			{
+				svSalesOrderFulfillmentPackages.Add( new NetSuiteSalesOrderFulfillmentPackage()
+				{
+					TrackingNumber = fedExPackage.packageTrackingNumberFedEx,
+					WeightLbs = (decimal)fedExPackage.packageWeightFedEx,
+					LengthInches = (decimal)fedExPackage.packageLengthFedEx,
+					WidthInches = (decimal)fedExPackage.packageWidthFedEx,
+					HeightInches = (decimal)fedExPackage.packageHeightFedEx,
+					InsuranceCost = (decimal)fedExPackage.insuredValueFedEx
+				} );
+			}
+
+			return svSalesOrderFulfillmentPackages;
+		}
+
+		private static IEnumerable< NetSuiteSalesOrderFulfillmentPackage > ToSVSalesOrderFulfillmentPackages( this NetSuiteSoapWS.ItemFulfillmentPackageUspsList uspsPackagesList )
+		{
+			var svSalesOrderFulfillmentPackages = new List< NetSuiteSalesOrderFulfillmentPackage >();
+			if ( uspsPackagesList?.packageUsps == null || uspsPackagesList.packageUsps.Length == 0 )
+				return svSalesOrderFulfillmentPackages;
+
+			foreach( var uspsPackage in uspsPackagesList.packageUsps )
+			{
+				svSalesOrderFulfillmentPackages.Add( new NetSuiteSalesOrderFulfillmentPackage()
+				{
+					TrackingNumber = uspsPackage.packageTrackingNumberUsps,
+					WeightLbs = (decimal)uspsPackage.packageWeightUsps,
+					LengthInches = (decimal)uspsPackage.packageLengthUsps,
+					WidthInches = (decimal)uspsPackage.packageWidthUsps,
+					HeightInches = (decimal)uspsPackage.packageHeightUsps,
+					ContentsDescription = uspsPackage.packageDescrUsps,
+					InsuranceCost = (decimal)uspsPackage.insuredValueUsps
+				} );
+			}
+
+			return svSalesOrderFulfillmentPackages;
+		}
+
+		private static IEnumerable< NetSuiteSalesOrderFulfillmentPackage > ToSVSalesOrderFulfillmentPackages( this NetSuiteSoapWS.ItemFulfillmentPackageUpsList upsPackagesList )
+		{
+			var svSalesOrderFulfillmentPackages = new List< NetSuiteSalesOrderFulfillmentPackage >();
+			if ( upsPackagesList?.packageUps == null || upsPackagesList.packageUps.Length == 0 )
+				return svSalesOrderFulfillmentPackages;
+
+			foreach( var upsPackage in upsPackagesList.packageUps )
+			{
+				svSalesOrderFulfillmentPackages.Add( new NetSuiteSalesOrderFulfillmentPackage()
+				{
+					TrackingNumber = upsPackage.packageTrackingNumberUps,
+					WeightLbs = (decimal)upsPackage.packageWeightUps,
+					LengthInches = (decimal)upsPackage.packageLengthUps,
+					WidthInches = (decimal)upsPackage.packageWidthUps,
+					HeightInches = (decimal)upsPackage.packageHeightUps,
+					ContentsDescription = upsPackage.packageDescrUps,
+					InsuranceCost = (decimal)upsPackage.insuredValueUps
+				} );
+			}
+
+			return svSalesOrderFulfillmentPackages;
+		}
+	}
+}

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.7.2.0</Version>
+    <Version>1.7.3.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.7.2.0</AssemblyVersion>
-    <FileVersion>1.7.2.0</FileVersion>
+    <AssemblyVersion>1.7.3.0</AssemblyVersion>
+    <FileVersion>1.7.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Services/Orders/INetSuiteOrdersService.cs
+++ b/src/NetSuiteAccess/Services/Orders/INetSuiteOrdersService.cs
@@ -8,7 +8,7 @@ namespace NetSuiteAccess.Services.Orders
 {
 	public interface INetSuiteOrdersService
 	{
-		Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token );
+		Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token, bool includeFulfillments = false );
 		Task CreateSalesOrderAsync( NetSuiteSalesOrder order, string locationName, CancellationToken token );
 		Task UpdateSalesOrderAsync( NetSuiteSalesOrder order, string locationName, CancellationToken token );
 		Task< IEnumerable< NetSuitePurchaseOrder > > GetPurchaseOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token );

--- a/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
+++ b/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
@@ -86,9 +86,9 @@ namespace NetSuiteAccess.Services.Orders
 		/// <param name="endDateUtc"></param>
 		/// <param name="token"></param>
 		/// <returns></returns>
-		public async Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
+		public async Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token, bool includeFulfillments = false )
 		{
-			var modifiedOrders = ( await _soapService.GetModifiedSalesOrdersAsync( startDateUtc, endDateUtc, token ).ConfigureAwait( false ) ).ToArray();
+			var modifiedOrders = ( await _soapService.GetModifiedSalesOrdersAsync( startDateUtc, endDateUtc, token, includeFulfillments ).ConfigureAwait( false ) ).ToArray();
 			var customers = ( await this._customersService.GetCustomersInfoByIdsAsync( modifiedOrders.Select( c => c.Customer.Id.ToString() ).Distinct().ToArray(), token ).ConfigureAwait( false ) ).ToList();
 			foreach( var order in modifiedOrders )
 			{

--- a/src/NetSuiteTests/NetSuiteTests.csproj
+++ b/src/NetSuiteTests/NetSuiteTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="ItemMapperTests.cs" />
     <Compile Include="ItemTests.cs" />
     <Compile Include="LocationMapperTests.cs" />
+    <Compile Include="OrderFulfillmentMapperTests.cs" />
     <Compile Include="OrderMapperTests.cs" />
     <Compile Include="OrderTests.cs" />
     <Compile Include="PageAdjusterTests.cs" />

--- a/src/NetSuiteTests/OrderFulfillmentMapperTests.cs
+++ b/src/NetSuiteTests/OrderFulfillmentMapperTests.cs
@@ -1,0 +1,226 @@
+﻿using FluentAssertions;
+using NetSuiteAccess.Models;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NetSuiteTests
+{
+	[ TestFixture ]
+	public class OrderFulfillmentMapperTests
+	{
+		[ Test ]
+		public void WhenToSVSalesOrderFulfillment_ThenFieldsAreMapped()
+		{
+			var nsOrderFulfillment = new NetSuiteSoapWS.ItemFulfillment()
+			{
+				internalId = "1",
+				tranId = "100",
+				createdDate = DateTime.UtcNow.AddDays( -1 ),
+				lastModifiedDate = DateTime.UtcNow,
+				shipStatus = NetSuiteSoapWS.ItemFulfillmentShipStatus._shipped,
+				shipMethod = new NetSuiteSoapWS.RecordRef()
+				{
+					name = "UPS 2nd Day Air"
+				},
+				shippingCost = 1.24,
+				memo = "Some note here",
+				itemList = new NetSuiteSoapWS.ItemFulfillmentItemList()
+				{
+					item = new NetSuiteSoapWS.ItemFulfillmentItem[]
+					{
+						new NetSuiteSoapWS.ItemFulfillmentItem()
+						{
+							itemName = "NS-testsku1",
+							quantity = 2
+						},
+						new NetSuiteSoapWS.ItemFulfillmentItem()
+						{
+							itemName = "NS-testsku2",
+							quantity = 4
+						}
+					}
+				},
+				packageUpsList = new NetSuiteSoapWS.ItemFulfillmentPackageUpsList()
+				{
+					packageUps = new NetSuiteSoapWS.ItemFulfillmentPackageUps[]
+					{
+						new NetSuiteSoapWS.ItemFulfillmentPackageUps()
+						{
+							packageTrackingNumberUps = "123456789ABCD",
+							packageWeightUps = 4.12,
+							packageDescrUps = "Fragile content",
+							packageLengthUps = 2,
+							packageHeightUps = 2,
+							packageWidthUps = 1,
+							insuredValueUps = 1.5
+						}
+					}
+				}
+			};
+
+			var svSalesOrderFulfillment = nsOrderFulfillment.ToSVSalesOrderFulfillment();
+
+			svSalesOrderFulfillment.Id.Should().Be( nsOrderFulfillment.internalId );
+			svSalesOrderFulfillment.TransactionId.Should().Be( nsOrderFulfillment.tranId );
+			svSalesOrderFulfillment.CreatedDateUtc.Should().Be( nsOrderFulfillment.createdDate.ToUniversalTime() );
+			svSalesOrderFulfillment.LastModifiedDateUtc.Should().Be( nsOrderFulfillment.lastModifiedDate.ToUniversalTime() );
+			svSalesOrderFulfillment.Note.Should().Be( nsOrderFulfillment.memo );
+			svSalesOrderFulfillment.Status.Should().Be( NetSuiteSalesOrderFulfillmentStatusEnum.Shipped );
+			svSalesOrderFulfillment.ShipmentCarrier.Should().Be( NetSuiteSalesOrderFulfillmentCarrierEnum.UPS );
+			svSalesOrderFulfillment.ShipmentClass.Should().Be( nsOrderFulfillment.shipMethod.name );
+			svSalesOrderFulfillment.ShippingCost.Should().Be( (decimal)nsOrderFulfillment.shippingCost );
+
+			svSalesOrderFulfillment.Items.Count().Should().Be( nsOrderFulfillment.itemList.item.Count() );
+			svSalesOrderFulfillment.Items.First().Name.Should().Be( nsOrderFulfillment.itemList.item.First().itemName );
+			svSalesOrderFulfillment.Items.First().Quantity.Should().Be( (int)nsOrderFulfillment.itemList.item.First().quantity );
+			svSalesOrderFulfillment.Items.Last().Name.Should().Be( nsOrderFulfillment.itemList.item.Last().itemName );
+			svSalesOrderFulfillment.Items.Last().Quantity.Should().Be( (int)nsOrderFulfillment.itemList.item.Last().quantity );
+
+			svSalesOrderFulfillment.Packages.Count().Should().Be( nsOrderFulfillment.packageUpsList.packageUps.Count() );
+			var svSalesOrderFulfillmentPackage = svSalesOrderFulfillment.Packages.First();
+			var nsOrderFulfillmentPackage = nsOrderFulfillment.packageUpsList.packageUps.First();
+			svSalesOrderFulfillmentPackage.TrackingNumber.Should().Be( nsOrderFulfillmentPackage.packageTrackingNumberUps );
+			svSalesOrderFulfillmentPackage.WeightLbs.Should().Be( (decimal)nsOrderFulfillmentPackage.packageWeightUps );
+			svSalesOrderFulfillmentPackage.WidthInches.Should().Be( nsOrderFulfillmentPackage.packageWidthUps );
+			svSalesOrderFulfillmentPackage.LengthInches.Should().Be( nsOrderFulfillmentPackage.packageLengthUps );
+			svSalesOrderFulfillmentPackage.HeightInches.Should().Be( nsOrderFulfillmentPackage.packageHeightUps );
+			svSalesOrderFulfillmentPackage.InsuranceCost.Should().Be( (decimal)nsOrderFulfillmentPackage.insuredValueUps );
+		}
+
+		[ Test ]
+		public void GivenNSOrderFulfillmentWithStatusPicked_WhenToSVSalesOrderFulfillmentIsCalled_ThenStatusIsMappedCorrectly()
+		{
+			var nsOrderFulfillment = GetNsOrder();
+			nsOrderFulfillment.shipStatus = NetSuiteSoapWS.ItemFulfillmentShipStatus._picked;
+
+			var svOrderFulfillment = nsOrderFulfillment.ToSVSalesOrderFulfillment();
+
+			svOrderFulfillment.Status.Should().Be( NetSuiteSalesOrderFulfillmentStatusEnum.Picked );
+		}
+
+		[ Test ]
+		public void GivenNsOrderFulfillmentWithStatusPacked_WhenToSVSalesOrderFulfillmentIsCalled_ThenStatusIsMappedCorrectly()
+		{
+			var nsOrderFulfillment = GetNsOrder();
+			nsOrderFulfillment.shipStatus = NetSuiteSoapWS.ItemFulfillmentShipStatus._packed;
+
+			var svOrderFulfillment = nsOrderFulfillment.ToSVSalesOrderFulfillment();
+
+			svOrderFulfillment.Status.Should().Be( NetSuiteSalesOrderFulfillmentStatusEnum.Packed );
+		}
+
+		[ Test ]
+		public void GivenNsOrderFulfillmentWithStatusShipped_WhenToSVSalesOrderFulfillmentIsCalled_ThenStatusIsMappedCorrectly()
+		{
+			var nsOrderFulfillment = GetNsOrder();
+			nsOrderFulfillment.shipStatus = NetSuiteSoapWS.ItemFulfillmentShipStatus._shipped;
+
+			var svOrderFulfillment = nsOrderFulfillment.ToSVSalesOrderFulfillment();
+
+			svOrderFulfillment.Status.Should().Be( NetSuiteSalesOrderFulfillmentStatusEnum.Shipped );
+		}
+
+		[ Test ]
+		public void GivenNsOrderFulfillmentWithUnknownCarrier_WhenToSVSalesOrderFulfillmentIsCalled_ThenOtherShipmentCarrierWithPackagesIsReturned()
+		{
+			var nsOrderFulfillment = GetNsOrder();
+			nsOrderFulfillment.packageList = new NetSuiteSoapWS.ItemFulfillmentPackageList()
+			{
+				package = new NetSuiteSoapWS.ItemFulfillmentPackage[]
+				{
+					new NetSuiteSoapWS.ItemFulfillmentPackage()
+					{
+						packageTrackingNumber = "ABCD12345",
+						packageWeight = 5.2,
+						packageDescr = "Fragile content"
+					}
+				}
+			};
+
+			var svOrderFulfillment = nsOrderFulfillment.ToSVSalesOrderFulfillment();
+
+			svOrderFulfillment.ShipmentCarrier.Should().Be( NetSuiteSalesOrderFulfillmentCarrierEnum.Other );
+			svOrderFulfillment.Packages.First().TrackingNumber.Should().Be( nsOrderFulfillment.packageList.package.First().packageTrackingNumber );
+			svOrderFulfillment.Packages.First().WeightLbs.Should().Be( (decimal)nsOrderFulfillment.packageList.package.First().packageWeight );
+			svOrderFulfillment.Packages.First().ContentsDescription.Should().Be( nsOrderFulfillment.packageList.package.First().packageDescr );
+		}
+
+		[ Test ]
+		public void GivenNsOrderFulfillmentWithFedExCarrier_WhenToSVSalesOrderFulfillmentIsCalled_ThenFedExShipmentCarrierWithPackagesIsReturned()
+		{
+			var nsOrderFulfillment = GetNsOrder();
+			nsOrderFulfillment.packageFedExList = new NetSuiteSoapWS.ItemFulfillmentPackageFedExList()
+			{
+				packageFedEx = new NetSuiteSoapWS.ItemFulfillmentPackageFedEx[]
+				{
+					new NetSuiteSoapWS.ItemFulfillmentPackageFedEx()
+					{
+						packageTrackingNumberFedEx = "XYZ12345",
+						packageWeightFedEx = 3.72,
+						packageLengthFedEx = 1,
+						packageWidthFedEx = 1,
+						packageHeightFedEx = 2,
+						insuredValueFedEx = 2.4
+					}
+				}
+			};
+
+			var svOrderFulfillment = nsOrderFulfillment.ToSVSalesOrderFulfillment();
+			svOrderFulfillment.ShipmentCarrier.Should().Be( NetSuiteSalesOrderFulfillmentCarrierEnum.FedEx );
+			svOrderFulfillment.Packages.First().TrackingNumber.Should().Be( nsOrderFulfillment.packageFedExList.packageFedEx.First().packageTrackingNumberFedEx );
+			svOrderFulfillment.Packages.First().WeightLbs.Should().Be( (decimal)nsOrderFulfillment.packageFedExList.packageFedEx.First().packageWeightFedEx );
+			svOrderFulfillment.Packages.First().LengthInches.Should().Be( nsOrderFulfillment.packageFedExList.packageFedEx.First().packageLengthFedEx );
+			svOrderFulfillment.Packages.First().WidthInches.Should().Be( nsOrderFulfillment.packageFedExList.packageFedEx.First().packageWidthFedEx );
+			svOrderFulfillment.Packages.First().HeightInches.Should().Be( nsOrderFulfillment.packageFedExList.packageFedEx.First().packageHeightFedEx );
+			svOrderFulfillment.Packages.First().InsuranceCost.Should().Be( (decimal)nsOrderFulfillment.packageFedExList.packageFedEx.First().insuredValueFedEx );
+		}
+
+		[ Test ]
+		public void GivenNsOrderFulfillmentWithUSPSCarrier_WhenToSVSalesOrderFulfillmentIsCalled_ThenUSPSShipmentCarrierWithPackagesIsReturned()
+		{
+			var nsOrderFulfillment = GetNsOrder();
+			nsOrderFulfillment.packageUspsList = new NetSuiteSoapWS.ItemFulfillmentPackageUspsList()
+			{
+				packageUsps = new NetSuiteSoapWS.ItemFulfillmentPackageUsps[]
+				{
+					new NetSuiteSoapWS.ItemFulfillmentPackageUsps()
+					{
+						packageTrackingNumberUsps = "TUWOQP12354",
+						packageDescrUsps = "Fragile",
+						packageWeightUsps = 3.14,
+						packageHeightUsps = 3,
+						packageWidthUsps = 2,
+						packageLengthUsps = 2,
+						insuredValueUsps = 4.48
+					}
+				}
+			};
+
+			var svOrderFulfillment = nsOrderFulfillment.ToSVSalesOrderFulfillment();
+
+			svOrderFulfillment.ShipmentCarrier.Should().Be( NetSuiteSalesOrderFulfillmentCarrierEnum.USPS );
+			svOrderFulfillment.Packages.First().TrackingNumber.Should().Be( nsOrderFulfillment.packageUspsList.packageUsps.First().packageTrackingNumberUsps );
+			svOrderFulfillment.Packages.First().ContentsDescription.Should().Be( nsOrderFulfillment.packageUspsList.packageUsps.First().packageDescrUsps );
+			svOrderFulfillment.Packages.First().WeightLbs.Should().Be( (decimal)nsOrderFulfillment.packageUspsList.packageUsps.First().packageWeightUsps );
+			svOrderFulfillment.Packages.First().HeightInches.Should().Be( nsOrderFulfillment.packageUspsList.packageUsps.First().packageHeightUsps );
+			svOrderFulfillment.Packages.First().WidthInches.Should().Be( nsOrderFulfillment.packageUspsList.packageUsps.First().packageWidthUsps );
+			svOrderFulfillment.Packages.First().LengthInches.Should().Be( nsOrderFulfillment.packageUspsList.packageUsps.First().packageLengthUsps );
+			svOrderFulfillment.Packages.First().InsuranceCost.Should().Be( (decimal)nsOrderFulfillment.packageUspsList.packageUsps.First().insuredValueUsps );
+		}
+
+		private NetSuiteSoapWS.ItemFulfillment GetNsOrder()
+		{
+			return new NetSuiteSoapWS.ItemFulfillment()
+			{
+				internalId = "1",
+				tranId = "100",
+				createdDate = DateTime.UtcNow.AddDays( -1 ),
+				lastModifiedDate = DateTime.UtcNow
+			};
+		}
+	}
+}

--- a/src/NetSuiteTests/OrderTests.cs
+++ b/src/NetSuiteTests/OrderTests.cs
@@ -41,6 +41,15 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
+		public void GetModifiedSalesOrdersWithFulfillments()
+		{
+			var salesOrders = this._ordersService.GetSalesOrdersAsync( DateTime.UtcNow.AddMonths( -1 ), DateTime.UtcNow, CancellationToken.None, true ).Result;
+			
+			salesOrders.Count().Should().BeGreaterThan( 0 );
+			salesOrders.Where( s => s.Fulfillments.Count() > 0 ).Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
 		public void GetModifiedPurchaseOrders()
 		{
 			var purchaseOrders = this._ordersService.GetPurchaseOrdersAsync( DateTime.UtcNow.AddDays( -14 ), DateTime.UtcNow, CancellationToken.None ).Result;


### PR DESCRIPTION
**Summary**
Now it's possible to pull sales order's fulfillments. By default, fulfillments aren't pulled to decrease pressure from SV side.

This PR also includes https://github.com/skuvault/netsuiteAccess/pull/29 (Taxes and Discounts)