### PR TITLE
2020-12-15 GUARD-938 Create-New-Customer-Record-For-New-Sales-Order-If-Necessary

### DIFF
--- a/src/NetSuiteAccess/Models/Customer.cs
+++ b/src/NetSuiteAccess/Models/Customer.cs
@@ -5,7 +5,7 @@ namespace NetSuiteAccess.Models
 	public class NetSuiteCustomer
 	{
 		[ JsonProperty( "id" ) ]
-		public long Id { get; set; }
+		public string Id { get; set; }
 		[ JsonProperty( "companyName" ) ]
 		public string CompanyName { get; set; }
 		[ JsonProperty( "firstName" ) ]
@@ -16,6 +16,17 @@ namespace NetSuiteAccess.Models
 		public string Email { get; set; }
 		[ JsonProperty( "phone" ) ]
 		public string Phone { get; set; }
+		public NetSuiteAddress Address { get; set; } 
+	}
+
+	public class NetSuiteAddress
+	{
+		public string Country { get; set; }
+		public string Region { get; set; }
+		public string City { get; set; }
+		public string Address1 { get; set; }
+		public string Address2 { get; set; }
+		public string PostalCode { get; set; }
 	}
 
 	public static class CustomerExtensions
@@ -24,7 +35,7 @@ namespace NetSuiteAccess.Models
 		{
 			return new NetSuiteCustomer()
 			{
-				Id = long.Parse( customer.internalId ),
+				Id = customer.internalId,
 				CompanyName = customer.companyName,
 				FirstName = customer.firstName,
 				LastName = customer.lastName,

--- a/src/NetSuiteAccess/Models/SalesOrder.cs
+++ b/src/NetSuiteAccess/Models/SalesOrder.cs
@@ -132,7 +132,7 @@ namespace NetSuiteAccess.Models
 
 			svOrder.Customer = new NetSuiteCustomer()
 			{
-				Id = int.Parse( order.entity.internalId )
+				Id = order.entity.internalId
 			};
 
 			return svOrder;

--- a/src/NetSuiteAccess/NetSuiteAccess.csproj
+++ b/src/NetSuiteAccess/NetSuiteAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/netsuiteAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/netsuiteAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/netsuiteAccess</RepositoryUrl>
-    <Version>1.7.3.0-alpha</Version>
+    <Version>1.7.4.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.7.3.0</AssemblyVersion>
-    <FileVersion>1.7.3.0</FileVersion>
+    <AssemblyVersion>1.7.4.0</AssemblyVersion>
+    <FileVersion>1.7.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetSuiteAccess/Services/Customers/INetSuiteCustomersService.cs
+++ b/src/NetSuiteAccess/Services/Customers/INetSuiteCustomersService.cs
@@ -11,6 +11,6 @@ namespace NetSuiteAccess.Services.Customers
 		Task< IEnumerable< NetSuiteCustomer > > GetCustomersInfoByIdsAsync( string[] customersIds, CancellationToken token );
 		Task< NetSuiteCustomer > GetCustomerInfoByIdAsync( string customerId, CancellationToken token );
 		Task< NetSuiteCustomer > GetCustomerInfoByEmailAsync( string email, CancellationToken token );
-		Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken token );
+		Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken token, Mark mark = null );
 	}
 }

--- a/src/NetSuiteAccess/Services/Customers/INetSuiteCustomersService.cs
+++ b/src/NetSuiteAccess/Services/Customers/INetSuiteCustomersService.cs
@@ -1,4 +1,5 @@
-﻿using NetSuiteAccess.Models;
+﻿using Netco.Logging;
+using NetSuiteAccess.Models;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,5 +11,6 @@ namespace NetSuiteAccess.Services.Customers
 		Task< IEnumerable< NetSuiteCustomer > > GetCustomersInfoByIdsAsync( string[] customersIds, CancellationToken token );
 		Task< NetSuiteCustomer > GetCustomerInfoByIdAsync( string customerId, CancellationToken token );
 		Task< NetSuiteCustomer > GetCustomerInfoByEmailAsync( string email, CancellationToken token );
+		Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken token );
 	}
 }

--- a/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
+++ b/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
@@ -51,5 +51,10 @@ namespace NetSuiteAccess.Services.Customers
 
 			return customers.Select( c => c.ToSVCustomer() );
 		}
+
+		public System.Threading.Tasks.Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken token )
+		{
+			return this._soapService.CreateCustomerAsync( customer, token );
+		}
 	}
 }

--- a/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
+++ b/src/NetSuiteAccess/Services/Customers/NetSuiteCustomersService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Netco.Logging;
 using NetSuiteAccess.Configuration;
 using NetSuiteAccess.Models;
 using NetSuiteAccess.Services.Soap;
@@ -52,9 +53,9 @@ namespace NetSuiteAccess.Services.Customers
 			return customers.Select( c => c.ToSVCustomer() );
 		}
 
-		public System.Threading.Tasks.Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken token )
+		public System.Threading.Tasks.Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken token, Mark mark = null )
 		{
-			return this._soapService.CreateCustomerAsync( customer, token );
+			return this._soapService.CreateCustomerAsync( customer, token, mark );
 		}
 	}
 }

--- a/src/NetSuiteAccess/Services/Orders/INetSuiteOrdersService.cs
+++ b/src/NetSuiteAccess/Services/Orders/INetSuiteOrdersService.cs
@@ -9,7 +9,7 @@ namespace NetSuiteAccess.Services.Orders
 	public interface INetSuiteOrdersService
 	{
 		Task< IEnumerable< NetSuiteSalesOrder > > GetSalesOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token, bool includeFulfillments = false );
-		Task CreateSalesOrderAsync( NetSuiteSalesOrder order, string locationName, CancellationToken token );
+		Task CreateSalesOrderAsync( NetSuiteSalesOrder order, string locationName, CancellationToken token, bool createCustomer = false );
 		Task UpdateSalesOrderAsync( NetSuiteSalesOrder order, string locationName, CancellationToken token );
 		Task< IEnumerable< NetSuitePurchaseOrder > > GetPurchaseOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token );
 		Task< IEnumerable< NetSuitePurchaseOrder > > GetAllPurchaseOrdersAsync( CancellationToken token );

--- a/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
+++ b/src/NetSuiteAccess/Services/Orders/NetSuiteOrdersService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Netco.Logging;
 using NetSuiteAccess.Configuration;
 using NetSuiteAccess.Exceptions;
 using NetSuiteAccess.Models;
@@ -106,6 +107,7 @@ namespace NetSuiteAccess.Services.Orders
 		/// <returns></returns>
 		public async Task CreateSalesOrderAsync( NetSuiteSalesOrder order, string locationName, CancellationToken token, bool createCustomer = false )
 		{
+			var mark = Mark.CreateNew();
 			var location = await this.GetLocationByNameAsync( locationName, token ).ConfigureAwait( false );
 
 			if ( location == null )
@@ -130,10 +132,10 @@ namespace NetSuiteAccess.Services.Orders
 					return;
 				}
 
-				customer = await this._soapService.CreateCustomerAsync( order.Customer, token ).ConfigureAwait( false );
+				customer = await this._soapService.CreateCustomerAsync( order.Customer, token, mark ).ConfigureAwait( false );
 			}
 
-			await this._soapService.CreateSalesOrderAsync( order, location.Id, customer.Id, token ).ConfigureAwait( false );
+			await this._soapService.CreateSalesOrderAsync( order, location.Id, customer.Id, token, mark ).ConfigureAwait( false );
 		}
 
 		/// <summary>

--- a/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
+++ b/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
@@ -381,6 +381,76 @@ namespace NetSuiteAccess.Services.Soap
 		}
 
 		/// <summary>
+		///	Creates new customer in NetSuite.
+		///	Requires Lists -> Customers role permission. Level - Full. 
+		/// </summary>
+		/// <param name="customer"></param>
+		/// <param name="mark"></param>
+		public async Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken cancellationToken )
+		{
+			var mark = Mark.CreateNew();
+
+			var newCustomerRecord = new NetSuiteSoapWS.Customer()
+			{
+				firstName = customer.FirstName,
+				lastName = customer.LastName,
+				email = customer.Email,
+				phone = customer.Phone,
+				companyName = customer.CompanyName,
+				isPerson = true,
+				isPersonSpecified = true
+			};
+
+			if ( customer.Address != null )
+			{
+				newCustomerRecord.addressbookList = new CustomerAddressbookList()
+				{
+					addressbook = new CustomerAddressbook[]
+					{
+						new CustomerAddressbook()
+						{
+							addressbookAddress = new Address()
+							{
+								country = Country._unitedStates,
+								countrySpecified = true,
+								city = customer.Address.City,
+								state = customer.Address.Region,
+								addr1 = customer.Address.Address1,
+								addr2 = customer.Address.Address2,
+								zip = customer.Address.PostalCode
+							}
+						}
+					}
+				};
+			}
+
+			var response = await this.ThrottleRequestAsync( mark, ( token ) =>
+			{
+				return this._service.addAsync( null, this._passport, null, null, null, newCustomerRecord );
+			}, newCustomerRecord.ToJson(), cancellationToken ).ConfigureAwait( false );
+
+			if ( !response.writeResponse.status.isSuccess )
+			{
+				if ( response.writeResponse.status.statusDetail[0].code == StatusDetailCodeType.UNIQUE_CUST_ID_REQD )
+				{
+					var existingCustomer = await GetCustomerByFirstAndLastName( customer.FirstName, customer.LastName, cancellationToken ).ConfigureAwait( false );
+					if ( existingCustomer == null )
+						throw new NetSuiteException( string.Format( "Can't find existing customer by first name {0} and last name {1}", customer.FirstName, customer.LastName ) );
+
+					return existingCustomer.ToSVCustomer();
+				}
+
+				throw new NetSuiteException( response.writeResponse.status.statusDetail[0].message );
+			}
+
+			var newCustomerRef = response.writeResponse.baseRef as RecordRef;
+			if ( newCustomerRef != null )
+				customer.Id = newCustomerRef.internalId;
+
+			return customer;
+		}
+
+		/// <summary>
 		///	Find customer by internal id
 		/// </summary>
 		/// <param name="internalId"></param>
@@ -444,6 +514,43 @@ namespace NetSuiteAccess.Services.Soap
 						@operator = SearchStringFieldOperator.@is,
 						operatorSpecified = true,
 						searchValue = email
+					}
+				}
+			};
+
+			var response = await this.SearchRecords( customerSearch, mark, cancellationToken ).ConfigureAwait( false );
+			return response.OfType< Customer >().FirstOrDefault();
+		}
+
+		public async Task< Customer > GetCustomerByFirstAndLastName( string firstName, string lastName, CancellationToken cancellationToken )
+		{
+			if ( string.IsNullOrWhiteSpace( firstName ) 
+				|| string.IsNullOrWhiteSpace( lastName ) )
+				return null;
+
+			var mark = Mark.CreateNew();
+
+			if ( cancellationToken.IsCancellationRequested )
+			{
+				var exceptionDetails = CallInfo.CreateInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() );
+				throw new NetSuiteException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+			}
+
+			var customerSearch = new CustomerSearch()
+			{
+				basic = new CustomerSearchBasic()
+				{
+					firstName = new SearchStringField()
+					{
+						@operator = SearchStringFieldOperator.@is,
+						operatorSpecified = true,
+						searchValue = firstName
+					},
+					lastName = new SearchStringField()
+					{
+						@operator = SearchStringFieldOperator.@is,
+						operatorSpecified = true,
+						searchValue = lastName
 					}
 				}
 			};
@@ -1014,7 +1121,7 @@ namespace NetSuiteAccess.Services.Soap
 		/// <param name="order">Sales order</param>
 		/// <param name="cancellationToken">Cancellation token</param>
 		/// <returns></returns>
-		public async System.Threading.Tasks.Task CreateSalesOrderAsync( NetSuiteSalesOrder order, long locationId, long customerId, CancellationToken cancellationToken )
+		public async System.Threading.Tasks.Task CreateSalesOrderAsync( NetSuiteSalesOrder order, long locationId, string customerId, CancellationToken cancellationToken )
 		{
 			var mark = Mark.CreateNew();
 
@@ -1033,7 +1140,7 @@ namespace NetSuiteAccess.Services.Soap
 				}, 
 				entity = new RecordRef()
 				{
-					internalId = customerId.ToString()
+					internalId = customerId
 				}, 
 			};
 
@@ -1082,7 +1189,7 @@ namespace NetSuiteAccess.Services.Soap
 		/// <param name="order">Sales order</param>
 		/// <param name="cancellationToken">Cancellation token</param>
 		/// <returns></returns>
-		public async System.Threading.Tasks.Task UpdateSalesOrderAsync( NetSuiteSalesOrder order, long locationId, long customerId, CancellationToken cancellationToken )
+		public async System.Threading.Tasks.Task UpdateSalesOrderAsync( NetSuiteSalesOrder order, long locationId, string customerId, CancellationToken cancellationToken )
 		{
 			var mark = Mark.CreateNew();
 
@@ -1097,7 +1204,7 @@ namespace NetSuiteAccess.Services.Soap
 				internalId = order.Id,
 				entity = new RecordRef()
 				{
-					internalId = customerId.ToString()
+					internalId = customerId
 				},
 				location = new RecordRef()
 				{

--- a/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
+++ b/src/NetSuiteAccess/Services/Soap/NetSuiteSoapService.cs
@@ -386,10 +386,8 @@ namespace NetSuiteAccess.Services.Soap
 		/// </summary>
 		/// <param name="customer"></param>
 		/// <param name="mark"></param>
-		public async Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken cancellationToken )
+		public async Task< NetSuiteCustomer > CreateCustomerAsync( NetSuiteCustomer customer, CancellationToken cancellationToken, Mark mark )
 		{
-			var mark = Mark.CreateNew();
-
 			var newCustomerRecord = new NetSuiteSoapWS.Customer()
 			{
 				firstName = customer.FirstName,
@@ -433,7 +431,7 @@ namespace NetSuiteAccess.Services.Soap
 			{
 				if ( response.writeResponse.status.statusDetail[0].code == StatusDetailCodeType.UNIQUE_CUST_ID_REQD )
 				{
-					var existingCustomer = await GetCustomerByFirstAndLastName( customer.FirstName, customer.LastName, cancellationToken ).ConfigureAwait( false );
+					var existingCustomer = await GetCustomerByFirstAndLastName( customer.FirstName, customer.LastName, cancellationToken, mark ).ConfigureAwait( false );
 					if ( existingCustomer == null )
 						throw new NetSuiteException( string.Format( "Can't find existing customer by first name {0} and last name {1}", customer.FirstName, customer.LastName ) );
 
@@ -522,13 +520,11 @@ namespace NetSuiteAccess.Services.Soap
 			return response.OfType< Customer >().FirstOrDefault();
 		}
 
-		public async Task< Customer > GetCustomerByFirstAndLastName( string firstName, string lastName, CancellationToken cancellationToken )
+		public async Task< Customer > GetCustomerByFirstAndLastName( string firstName, string lastName, CancellationToken cancellationToken, Mark mark )
 		{
 			if ( string.IsNullOrWhiteSpace( firstName ) 
 				|| string.IsNullOrWhiteSpace( lastName ) )
 				return null;
-
-			var mark = Mark.CreateNew();
 
 			if ( cancellationToken.IsCancellationRequested )
 			{
@@ -1121,10 +1117,8 @@ namespace NetSuiteAccess.Services.Soap
 		/// <param name="order">Sales order</param>
 		/// <param name="cancellationToken">Cancellation token</param>
 		/// <returns></returns>
-		public async System.Threading.Tasks.Task CreateSalesOrderAsync( NetSuiteSalesOrder order, long locationId, string customerId, CancellationToken cancellationToken )
+		public async System.Threading.Tasks.Task CreateSalesOrderAsync( NetSuiteSalesOrder order, long locationId, string customerId, CancellationToken cancellationToken, Mark mark )
 		{
-			var mark = Mark.CreateNew();
-
 			if ( cancellationToken.IsCancellationRequested )
 			{
 				var exceptionDetails = CallInfo.CreateInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() );

--- a/src/NetSuiteTests/CustomerTests.cs
+++ b/src/NetSuiteTests/CustomerTests.cs
@@ -4,6 +4,8 @@ using NetSuiteAccess.Services.Customers;
 using NUnit.Framework;
 using System.Threading;
 using System.Threading.Tasks;
+using NetSuiteAccess.Models;
+using Netco.Logging;
 
 namespace NetSuiteTests
 {
@@ -59,6 +61,36 @@ namespace NetSuiteTests
 			var result = await this._customersService.GetCustomersInfoByIdsAsync( customersIds, CancellationToken.None );
 
 			result.Should().NotBeNull();
+		}
+
+		[ Test ]
+		public async Task CreateCustomerAsync()
+		{
+			var firstName = "Ivan" + new Random().Next( 1, 1000 );
+			var email = "ivan.ivanov" + Guid.NewGuid().ToString().Substring( 0, 5 ) + "@skuvault.com";
+			var newCustomer = new NetSuiteCustomer()
+			{
+				FirstName = firstName,
+				LastName = "Ivanov",
+				Email = email,
+				Phone = "1-502-694-5210",
+				CompanyName = "SkuVault",
+				Address = new NetSuiteAddress()
+				{
+					Country = "USA",
+					City = "Louisville",
+					Region = "KY",
+					Address1 = "2509 Plantside Drive",
+					PostalCode = "40299"
+				}
+			};
+
+			await this._customersService.CreateCustomerAsync( newCustomer, CancellationToken.None );
+
+			var nsCustomerInfo = await this._customersService.GetCustomerInfoByEmailAsync( email, CancellationToken.None );
+			nsCustomerInfo.FirstName.Should().Be( firstName );
+			nsCustomerInfo.LastName.Should().Be( newCustomer.LastName );
+			nsCustomerInfo.Email.Should().Be( email );
 		}
 	}
 }

--- a/src/NetSuiteTests/OrderTests.cs
+++ b/src/NetSuiteTests/OrderTests.cs
@@ -253,6 +253,53 @@ namespace NetSuiteTests
 		}
 
 		[ Test ]
+		public async Task GivenSalesOrderMadeByNewCustomer_WhenCreateSalesOrderIsCalled_ThenCreatedSalesOrderIsExpected()
+		{
+			var docNumber = "SO_" + Guid.NewGuid().ToString();
+			var order = this.GenerateSalesOrder( docNumber );
+			order.Customer.Email = "ivan.ivanov" + GenerateRandomPrefix() + "@skuvault.com";
+			order.Customer.FirstName = "Ivan";
+			order.Customer.LastName = "Ivanov_" + GenerateRandomPrefix();
+
+			await this._ordersService.CreateSalesOrderAsync( order, _locationName, CancellationToken.None, true );
+
+			var createdOrder = await GetRecentlyModifiedSalesOrderByDocNumber( docNumber );
+			createdOrder.Should().NotBeNull();
+		}
+
+		[ Test ]
+		public async Task GivenSalesOrderMadeByNewCustomer_WhenCreateSalesOrderIsCalledWithDisabledAutomaticCustomerCreationFeature_ThenExceptionIsExpected()
+		{
+			var docNumber = "SO_" + Guid.NewGuid().ToString();
+			var order = this.GenerateSalesOrder( docNumber );
+
+			order.Customer.Email = "ivan.ivanov" + GenerateRandomPrefix() + "@skuvault.com";
+			order.Customer.FirstName = "Ivan";
+			order.Customer.LastName = "Ivanov_" + GenerateRandomPrefix();
+
+			await this._ordersService.CreateSalesOrderAsync( order, _locationName, CancellationToken.None, false );
+
+			var createdOrder = await GetRecentlyModifiedSalesOrderByDocNumber( docNumber );
+			createdOrder.Should().BeNull();
+		}
+
+		[ Test ]
+		public async Task GivenSalesOrderMadeByNewCustomerWithSameNameInNetSuiteButDifferentEmail_WhenCreateSalesOrderIsCalled_ThenCreatedSalesOrderIsExpected()
+		{
+			var docNumber = "SO_" + Guid.NewGuid().ToString();
+			var order = this.GenerateSalesOrder( docNumber );
+
+			order.Customer.Email = "ivan.ivanov" + GenerateRandomPrefix() + "@skuvault.com";
+			order.Customer.FirstName = "Ivan";
+			order.Customer.LastName = "Ivanov";
+
+			await this._ordersService.CreateSalesOrderAsync( order, _locationName, CancellationToken.None, true );
+
+			var createdOrder = await GetRecentlyModifiedSalesOrderByDocNumber( docNumber );
+			createdOrder.Should().NotBeNull();
+		}
+
+		[ Test ]
 		public async Task UpdateSalesOrder()
 		{
 			var docNumber = "SO_" + Guid.NewGuid().ToString();
@@ -312,6 +359,11 @@ namespace NetSuiteTests
 			}
 			var orders = await this._ordersService.GetSalesOrdersAsync( startDate.Value, DateTime.UtcNow, CancellationToken.None );
 			return orders.FirstOrDefault( o => o.DocNumber.Equals( docNumber ) );
+		}
+
+		private string GenerateRandomPrefix()
+		{
+			return Guid.NewGuid().ToString().Substring( 0, 5 );
 		}
 	}
 }


### PR DESCRIPTION
**Summary**
New customer record now can be automatically created for new sales order.

Found out one serious limitation in NetSuite. Primary key for customer record in NetSuite is first and last name only (not email!).